### PR TITLE
ADD failed proxy error handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# JetBrains
+/.idea 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub(crate) use rewind::Rewind;
 pub use async_trait;
 use http::StatusCode;
 pub use hyper;
-pub use tracing::error;
+use tracing::error;
 #[cfg(feature = "openssl-ca")]
 pub use openssl;
 pub use tokio_rustls::rustls;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ use tokio_tungstenite::tungstenite::Message;
 pub(crate) use rewind::Rewind;
 
 pub use async_trait;
+use http::StatusCode;
 pub use hyper;
 #[cfg(feature = "openssl-ca")]
 pub use openssl;
@@ -117,6 +118,12 @@ pub trait HttpHandler: Clone + Send + Sync + 'static {
     /// Whether a CONNECT request should be intercepted. Defaults to `true` for all requests.
     async fn should_intercept(&mut self, _ctx: &HttpContext, _req: &Request<Body>) -> bool {
         true
+    }
+
+    // The error handler is failed if a proxy request fails. Default response is a 502 Bad Gateway
+    async fn handle_error(&mut self, _ctx: &HttpContext, err: hyper::Error) -> Response<Body> {
+        eprintln!("hudsucker failed to forward request: {}", err);
+        Response::builder().status(StatusCode::BAD_GATEWAY).body(Body::from("502 Bad Gateway")).unwrap()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub(crate) use rewind::Rewind;
 pub use async_trait;
 use http::StatusCode;
 pub use hyper;
+pub use tracing::error;
 #[cfg(feature = "openssl-ca")]
 pub use openssl;
 pub use tokio_rustls::rustls;
@@ -120,10 +121,13 @@ pub trait HttpHandler: Clone + Send + Sync + 'static {
         true
     }
 
-    // The error handler is failed if a proxy request fails. Default response is a 502 Bad Gateway
+    /// The handler will be called if a proxy request fails. Default response is a 502 Bad Gateway.
     async fn handle_error(&mut self, _ctx: &HttpContext, err: hyper::Error) -> Response<Body> {
-        eprintln!("hudsucker failed to forward request: {}", err);
-        Response::builder().status(StatusCode::BAD_GATEWAY).body(Body::from("502 Bad Gateway")).unwrap()
+        error!("Failed to forward request: {}", err);
+        Response::builder()
+            .status(StatusCode::BAD_GATEWAY)
+            .body(Body::empty())
+            .expect("Failed to build response")
     }
 }
 

--- a/src/proxy/internal.rs
+++ b/src/proxy/internal.rs
@@ -111,16 +111,14 @@ where
                 .instrument(info_span!("proxy_request"))
                 .await;
 
-            if res.is_err() {
-                return Ok(self.http_handler.handle_error(&ctx, res.unwrap_err()).await);
+            match res {
+                Err(e) => Ok(self.http_handler.handle_error(&ctx, e).await),
+                Ok(res) => Ok(self
+                    .http_handler
+                    .handle_response(&ctx, res)
+                    .instrument(info_span!("handle_response"))
+                    .await)
             }
-            let res = res.unwrap();
-
-            Ok(self
-                .http_handler
-                .handle_response(&ctx, res)
-                .instrument(info_span!("handle_response"))
-                .await)
         }
     }
 

--- a/src/proxy/internal.rs
+++ b/src/proxy/internal.rs
@@ -109,7 +109,12 @@ where
                 .client
                 .request(normalize_request(req))
                 .instrument(info_span!("proxy_request"))
-                .await?;
+                .await;
+
+            if res.is_err() {
+                return Ok(self.http_handler.handle_error(&ctx, res.unwrap_err()).await);
+            }
+            let res = res.unwrap();
 
             Ok(self
                 .http_handler


### PR DESCRIPTION
I'm trying to integrate this into a small service within a cluster I run and I've found that a failed proxy requests by default result in an empty server response with no error message server side. I've found that this comes from one somewhat unsafe `?` unwrap in the internal proxy.

I've slightly modified this so that there is now a `handle_error` on the HttpHandler trait that takes the error from hyper and returns a response. By default I have it returning a `502 Bad Gateway`.
