### PR TITLE
Add 'vendored' feature for openssl package to fix building in GitHub Actions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ hyper-rustls = { version = "0.24.0", default-features = false, features = ["http
 hyper-tls = { version = "0.5.0", optional = true }
 hyper-tungstenite = "0.10.0"
 moka = { version = "0.11.0", features = ["future"], optional = true }
-openssl = { version = "0.10.39", optional = true }
+openssl = { version = "0.10.39", optional = true, features = ["vendored"] }
 rand = { version = "0.8.0", optional = true }
 rcgen = { version = "0.11.0", features = ["x509-parser"], optional = true }
 thiserror = "1.0.30"


### PR DESCRIPTION
#### Issue
I have a project which uses hudsucker, I was trying to build it in GitHub actions for Apple M1 OS but was failing on openssl. It is mentioned in the openssl docs to use

https://docs.rs/openssl/latest/openssl/#vendored
```toml
openssl = { version = "0.10", features = ["vendored"] }
```
as the dependency. I add "vendored" features and that fixed the issue.
