### PR TITLE
chore: dependency bumps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hudsucker"
-version = "0.22.0"
+version = "0.22.1"
 edition = "2021"
 rust-version = "1.75.0"
 description = "MITM HTTP/S proxy"
@@ -18,38 +18,38 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-async-compression = { version = "0.4.0", features = ["tokio", "brotli", "gzip", "zlib", "zstd"], optional = true }
-bstr = "1.0.0"
-futures = "0.3.11"
+async-compression = { version = "0.4.12", features = ["tokio", "brotli", "gzip", "zlib", "zstd"], optional = true }
+bstr = "1.10.0"
+futures = "0.3.30"
 http = "1.1.0"
-http-body-util = "0.1.0"
-hyper = "1.1.0"
-hyper-rustls = { version = "0.26.0", default-features = false, features = ["http1", "logging", "ring", "tls12", "webpki-tokio"], optional = true }
+http-body-util = "0.1.2"
+hyper = "1.4.1"
+hyper-rustls = { version = "0.27.3", default-features = false, features = ["http1", "logging", "ring", "tls12", "webpki-tokio"], optional = true }
 hyper-tls = { version = "0.6.0", optional = true }
-hyper-tungstenite = "0.13.0"
-hyper-util = { version="0.1.3", features = ["client-legacy", "server", "http1"] }
-moka = { version = "0.12.0", features = ["future"], optional = true }
-openssl = { version = "0.10.46", optional = true }
-rand = { version = "0.8.0", optional = true }
-rcgen = { version = "0.13.0", features = ["x509-parser"], optional = true }
-thiserror = "1.0.30"
-time = { version = "0.3.20", optional = true }
-tokio = { version = "1.24.2", features = ["macros", "rt"] }
+hyper-tungstenite = "0.14.0"
+hyper-util = { version = "0.1.8", features = ["client-legacy", "server", "http1"] }
+moka = { version = "0.12.8", features = ["future"], optional = true }
+openssl = { version = "0.10.66", optional = true }
+rand = { version = "0.8.5", optional = true }
+rcgen = { version = "0.13.1", features = ["x509-parser"], optional = true }
+thiserror = "1.0.63"
+time = { version = "0.3.36", optional = true }
+tokio = { version = "1.40.0", features = ["macros", "rt"] }
 tokio-graceful = "0.1.6"
-tokio-rustls = "0.25.0"
-tokio-tungstenite = "0.21.0"
-tokio-util = { version = "0.7.1", features = ["io"], optional = true }
-tracing = { version = "0.1.35", features = ["log"] }
+tokio-rustls = { version = "0.26.0", default-features = false, features = ["logging", "tls12", "ring"]}
+tokio-tungstenite = "0.23.1"
+tokio-util = { version = "0.7.12", features = ["io"], optional = true }
+tracing = { version = "0.1.40", features = ["log"] }
 
 [dev-dependencies]
 async-http-proxy = { version = "1.2.5", features = ["runtime-tokio"] }
-criterion = { version = "0.5.0", features = ["async_tokio"] }
-reqwest = "0.12.0"
-rustls-native-certs = "0.7.0"
-rustls-pemfile = "2.0.0"
-tokio = { version = "1.24.2", features = ["full"] }
+criterion = { version = "0.5.1", features = ["async_tokio"] }
+reqwest = "0.12.7"
+rustls-native-certs = "0.8.0"
+rustls-pemfile = "2.1.3"
+tokio = { version = "1.40.0", features = ["full"] }
 tokio-native-tls = "0.3.1"
-tracing-subscriber = "0.3.8"
+tracing-subscriber = "0.3.18"
 x509-parser = "0.16.0"
 
 [features]


### PR DESCRIPTION
* Updated crate dependencies to latest
* Changed tokio-rustls features to not include the `aws_lc_rs` crypto library by default as it caused issues with the ring crypto provider
  * Users can still use `aws-lc-rs` for their crypto provider in downstream usages of hudsucker
