### PR TITLE
bump rcgen version, use new issuer struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ hyper-util = { version="0.1.3", features = ["client-legacy", "server", "http1"] 
 moka = { version = "0.12.0", features = ["future"], optional = true }
 openssl = { version = "0.10.46", optional = true }
 rand = { version = "0.9.0", optional = true }
-rcgen = { version = "0.13.0", features = ["x509-parser"], optional = true }
+rcgen = { version = "0.14.4", features = ["x509-parser"], optional = true }
 thiserror = "2.0.7"
 time = { version = "0.3.35", optional = true }
 tokio = { version = "1.24.2", features = ["macros", "rt"] }

--- a/benches/certificate_authorities.rs
+++ b/benches/certificate_authorities.rs
@@ -3,7 +3,7 @@ use http::uri::Authority;
 use hudsucker::{
     certificate_authority::{CertificateAuthority, OpensslAuthority, RcgenAuthority},
     openssl::{hash::MessageDigest, pkey::PKey, x509::X509},
-    rcgen::{CertificateParams, KeyPair},
+    rcgen::{Issuer, KeyPair},
     rustls::crypto::aws_lc_rs,
 };
 
@@ -17,12 +17,10 @@ fn build_rcgen_ca(cache_size: u64) -> RcgenAuthority {
     let key_pair = include_str!("../examples/ca/hudsucker.key");
     let ca_cert = include_str!("../examples/ca/hudsucker.cer");
     let key_pair = KeyPair::from_pem(key_pair).expect("Failed to parse private key");
-    let ca_cert = CertificateParams::from_ca_cert_pem(ca_cert)
-        .expect("Failed to parse CA certificate")
-        .self_signed(&key_pair)
-        .expect("Failed to sign CA certificate");
+    let issuer =
+        Issuer::from_ca_cert_pem(ca_cert, key_pair).expect("Failed to parse CA certificate");
 
-    RcgenAuthority::new(key_pair, ca_cert, cache_size, aws_lc_rs::default_provider())
+    RcgenAuthority::new(issuer, cache_size, aws_lc_rs::default_provider())
 }
 
 fn build_openssl_ca(cache_size: u64) -> OpensslAuthority {

--- a/benches/proxy.rs
+++ b/benches/proxy.rs
@@ -8,7 +8,7 @@ use hudsucker::{
         rt::{TokioExecutor, TokioIo},
         server::conn::auto,
     },
-    rcgen::{CertificateParams, KeyPair},
+    rcgen::{Issuer, KeyPair},
     rustls::crypto::aws_lc_rs,
 };
 use reqwest::Certificate;
@@ -29,12 +29,10 @@ fn build_ca() -> RcgenAuthority {
     let key_pair = include_str!("../examples/ca/hudsucker.key");
     let ca_cert = include_str!("../examples/ca/hudsucker.cer");
     let key_pair = KeyPair::from_pem(key_pair).expect("Failed to parse private key");
-    let ca_cert = CertificateParams::from_ca_cert_pem(ca_cert)
-        .expect("Failed to parse CA certificate")
-        .self_signed(&key_pair)
-        .expect("Failed to sign CA certificate");
+    let issuer =
+        Issuer::from_ca_cert_pem(ca_cert, key_pair).expect("Failed to parse CA certificate");
 
-    RcgenAuthority::new(key_pair, ca_cert, 1000, aws_lc_rs::default_provider())
+    RcgenAuthority::new(issuer, 1000, aws_lc_rs::default_provider())
 }
 
 async fn test_server(req: Request<Incoming>) -> Result<Response<Body>, Infallible> {

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -1,7 +1,7 @@
 use hudsucker::{
     certificate_authority::RcgenAuthority,
     hyper::{Request, Response},
-    rcgen::{CertificateParams, KeyPair},
+    rcgen::{Issuer, KeyPair},
     rustls::crypto::aws_lc_rs,
     tokio_tungstenite::tungstenite::Message,
     *,
@@ -48,12 +48,10 @@ async fn main() {
     let key_pair = include_str!("ca/hudsucker.key");
     let ca_cert = include_str!("ca/hudsucker.cer");
     let key_pair = KeyPair::from_pem(key_pair).expect("Failed to parse private key");
-    let ca_cert = CertificateParams::from_ca_cert_pem(ca_cert)
-        .expect("Failed to parse CA certificate")
-        .self_signed(&key_pair)
-        .expect("Failed to sign CA certificate");
+    let issuer =
+        Issuer::from_ca_cert_pem(ca_cert, key_pair).expect("Failed to parse CA certificate");
 
-    let ca = RcgenAuthority::new(key_pair, ca_cert, 1_000, aws_lc_rs::default_provider());
+    let ca = RcgenAuthority::new(issuer, 1_000, aws_lc_rs::default_provider());
 
     let proxy = Proxy::builder()
         .with_addr(SocketAddr::from(([127, 0, 0, 1], 3000)))

--- a/examples/noop.rs
+++ b/examples/noop.rs
@@ -1,6 +1,6 @@
 use hudsucker::{
     certificate_authority::RcgenAuthority,
-    rcgen::{CertificateParams, KeyPair},
+    rcgen::{Issuer, KeyPair},
     rustls::crypto::aws_lc_rs,
     *,
 };
@@ -20,12 +20,10 @@ async fn main() {
     let key_pair = include_str!("ca/hudsucker.key");
     let ca_cert = include_str!("ca/hudsucker.cer");
     let key_pair = KeyPair::from_pem(key_pair).expect("Failed to parse private key");
-    let ca_cert = CertificateParams::from_ca_cert_pem(ca_cert)
-        .expect("Failed to parse CA certificate")
-        .self_signed(&key_pair)
-        .expect("Failed to sign CA certificate");
+    let issuer =
+        Issuer::from_ca_cert_pem(ca_cert, key_pair).expect("Failed to parse CA certificate");
 
-    let ca = RcgenAuthority::new(key_pair, ca_cert, 1_000, aws_lc_rs::default_provider());
+    let ca = RcgenAuthority::new(issuer, 1_000, aws_lc_rs::default_provider());
 
     let proxy = Proxy::builder()
         .with_addr(SocketAddr::from(([127, 0, 0, 1], 3000)))

--- a/src/proxy/builder.rs
+++ b/src/proxy/builder.rs
@@ -38,19 +38,17 @@ pub enum Error {
 /// use hudsucker::Proxy;
 /// # use hudsucker::{
 /// #     certificate_authority::RcgenAuthority,
-/// #     rcgen::{CertificateParams, KeyPair},
+/// #     rcgen::{Issuer, KeyPair},
 /// #     rustls::crypto::aws_lc_rs,
 /// # };
 /// #
 /// # let key_pair = include_str!("../../examples/ca/hudsucker.key");
 /// # let ca_cert = include_str!("../../examples/ca/hudsucker.cer");
 /// # let key_pair = KeyPair::from_pem(key_pair).expect("Failed to parse private key");
-/// # let ca_cert = CertificateParams::from_ca_cert_pem(ca_cert)
-/// #     .expect("Failed to parse CA certificate")
-/// #     .self_signed(&key_pair)
-/// #     .expect("Failed to sign CA certificate");
+/// # let issuer =
+/// #     Issuer::from_ca_cert_pem(ca_cert, key_pair).expect("Failed to parse CA certificate");
 /// #
-/// # let ca = RcgenAuthority::new(key_pair, ca_cert, 1_000, aws_lc_rs::default_provider());
+/// # let ca = RcgenAuthority::new(issuer, 1_000, aws_lc_rs::default_provider());
 ///
 /// // let ca = ...;
 ///

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -28,7 +28,7 @@ use tracing::error;
 /// use hudsucker::Proxy;
 /// # use hudsucker::{
 /// #     certificate_authority::RcgenAuthority,
-/// #     rcgen::{CertificateParams, KeyPair},
+/// #     rcgen::{Issuer, KeyPair},
 /// #     rustls::crypto::aws_lc_rs,
 /// # };
 /// #
@@ -38,12 +38,10 @@ use tracing::error;
 /// # let key_pair = include_str!("../../examples/ca/hudsucker.key");
 /// # let ca_cert = include_str!("../../examples/ca/hudsucker.cer");
 /// # let key_pair = KeyPair::from_pem(key_pair).expect("Failed to parse private key");
-/// # let ca_cert = CertificateParams::from_ca_cert_pem(ca_cert)
-/// #     .expect("Failed to parse CA certificate")
-/// #     .self_signed(&key_pair)
-/// #     .expect("Failed to sign CA certificate");
+/// # let issuer =
+/// #     Issuer::from_ca_cert_pem(ca_cert, key_pair).expect("Failed to parse CA certificate");
 /// #
-/// # let ca = RcgenAuthority::new(key_pair, ca_cert, 1_000, aws_lc_rs::default_provider());
+/// # let ca = RcgenAuthority::new(issuer, 1_000, aws_lc_rs::default_provider());
 ///
 /// // let ca = ...;
 ///

--- a/tests/rcgen_ca.rs
+++ b/tests/rcgen_ca.rs
@@ -1,6 +1,6 @@
 use hudsucker::{
     certificate_authority::RcgenAuthority,
-    rcgen::{CertificateParams, KeyPair},
+    rcgen::{Issuer, KeyPair},
     rustls::crypto::aws_lc_rs,
 };
 use std::sync::atomic::Ordering;
@@ -11,12 +11,10 @@ fn build_ca() -> RcgenAuthority {
     let key_pair = include_str!("../examples/ca/hudsucker.key");
     let ca_cert = include_str!("../examples/ca/hudsucker.cer");
     let key_pair = KeyPair::from_pem(key_pair).expect("Failed to parse private key");
-    let ca_cert = CertificateParams::from_ca_cert_pem(ca_cert)
-        .expect("Failed to parse CA certificate")
-        .self_signed(&key_pair)
-        .expect("Failed to sign CA certificate");
+    let issuer =
+        Issuer::from_ca_cert_pem(ca_cert, key_pair).expect("Failed to parse CA certificate");
 
-    RcgenAuthority::new(key_pair, ca_cert, 1000, aws_lc_rs::default_provider())
+    RcgenAuthority::new(issuer, 1000, aws_lc_rs::default_provider())
 }
 
 #[tokio::test]

--- a/tests/websocket.rs
+++ b/tests/websocket.rs
@@ -2,7 +2,7 @@ use async_http_proxy::http_connect_tokio;
 use futures::{SinkExt, StreamExt};
 use hudsucker::{
     certificate_authority::RcgenAuthority,
-    rcgen::{CertificateParams, KeyPair},
+    rcgen::{Issuer, KeyPair},
     rustls::crypto::aws_lc_rs,
     tokio_tungstenite::tungstenite::{Message, Utf8Bytes},
 };
@@ -18,12 +18,10 @@ fn build_ca() -> RcgenAuthority {
     let key_pair = include_str!("../examples/ca/hudsucker.key");
     let ca_cert = include_str!("../examples/ca/hudsucker.cer");
     let key_pair = KeyPair::from_pem(key_pair).expect("Failed to parse private key");
-    let ca_cert = CertificateParams::from_ca_cert_pem(ca_cert)
-        .expect("Failed to parse CA certificate")
-        .self_signed(&key_pair)
-        .expect("Failed to sign CA certificate");
+    let issuer =
+        Issuer::from_ca_cert_pem(ca_cert, key_pair).expect("Failed to parse CA certificate");
 
-    RcgenAuthority::new(key_pair, ca_cert, 1000, aws_lc_rs::default_provider())
+    RcgenAuthority::new(issuer, 1000, aws_lc_rs::default_provider())
 }
 
 #[tokio::test]


### PR DESCRIPTION
Hi, new versions of the rcgen have introduced breaking changes (see https://github.com/rustls/rcgen/releases/tag/v0.14.0). I've updated it and fixed the RcgenAuthority