### PR TITLE
feat: add PreserveHost extension to skip Host header removal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,20 +49,7 @@ pub use error::Error;
 pub use noop::*;
 pub use proxy::*;
 
-/// Insert into request extensions to prevent `normalize_request` from stripping
-/// the `Host` header. Useful for reverse proxies that need to forward the
-/// original `Host` to the upstream server.
-///
-/// ```
-/// use hudsucker::PreserveHost;
-/// use hyper::Request;
-///
-/// let mut req = Request::builder()
-///     .uri("http://localhost:3000/")
-///     .body(())
-///     .unwrap();
-/// req.extensions_mut().insert(PreserveHost);
-/// ```
+/// When present in request extensions, the `Host` header will not be removed during normalization.
 #[derive(Debug, Clone, Copy)]
 pub struct PreserveHost;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,23 @@ pub use error::Error;
 pub use noop::*;
 pub use proxy::*;
 
+/// Insert into request extensions to prevent `normalize_request` from stripping
+/// the `Host` header. Useful for reverse proxies that need to forward the
+/// original `Host` to the upstream server.
+///
+/// ```
+/// use hudsucker::PreserveHost;
+/// use hyper::Request;
+///
+/// let mut req = Request::builder()
+///     .uri("http://localhost:3000/")
+///     .body(())
+///     .unwrap();
+/// req.extensions_mut().insert(PreserveHost);
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct PreserveHost;
+
 /// Enum representing either an HTTP request or response.
 #[derive(Debug)]
 pub enum RequestOrResponse {

--- a/src/proxy/internal.rs
+++ b/src/proxy/internal.rs
@@ -381,7 +381,10 @@ fn spawn_message_forwarder(
 #[instrument(skip_all)]
 fn normalize_request<T>(mut req: Request<T>) -> Request<T> {
     // Hyper will automatically add a Host header if needed.
-    req.headers_mut().remove(hyper::header::HOST);
+    // If PreserveHost is set in extensions, keep the original Host header.
+    if req.extensions().get::<crate::PreserveHost>().is_none() {
+        req.headers_mut().remove(hyper::header::HOST);
+    }
 
     // HTTP/2 supports multiple cookie headers, but HTTP/1.x only supports one.
     if let Entry::Occupied(mut cookies) = req.headers_mut().entry(hyper::header::COOKIE) {
@@ -443,6 +446,23 @@ mod tests {
             let req = normalize_request(req);
 
             assert_eq!(req.headers().get(hyper::header::HOST), None);
+        }
+
+        #[test]
+        fn preserves_host_header_with_extension() {
+            let mut req = Request::builder()
+                .uri("http://localhost:3000/")
+                .header(hyper::header::HOST, "example.com")
+                .body(())
+                .unwrap();
+            req.extensions_mut().insert(crate::PreserveHost);
+
+            let req = normalize_request(req);
+
+            assert_eq!(
+                req.headers().get(hyper::header::HOST).unwrap(),
+                "example.com"
+            );
         }
 
         #[test]

--- a/src/proxy/internal.rs
+++ b/src/proxy/internal.rs
@@ -380,8 +380,6 @@ fn spawn_message_forwarder(
 
 #[instrument(skip_all)]
 fn normalize_request<T>(mut req: Request<T>) -> Request<T> {
-    // Hyper will automatically add a Host header if needed.
-    // If PreserveHost is set in extensions, keep the original Host header.
     if req.extensions().get::<crate::PreserveHost>().is_none() {
         req.headers_mut().remove(hyper::header::HOST);
     }


### PR DESCRIPTION
# feat: add `PreserveHost` extension to opt out of Host header removal

## Summary

This adds a `PreserveHost` marker type that can be inserted into request extensions during `handle_request` to prevent `normalize_request` from stripping the `Host` header. The current behavior (unconditional removal) is preserved as the default.

## Problem

`normalize_request` unconditionally removes the `Host` header before forwarding:

```rust
fn normalize_request<T>(mut req: Request<T>) -> Request<T> {
    req.headers_mut().remove(hyper::header::HOST);
    // ...
}
```

This runs after `HttpHandler::handle_request` returns, so any `Host` header set by the handler is always discarded. Hyper then regenerates it from the URI authority.

For reverse proxy use cases where the request URI is rewritten to a local target (e.g. `http://localhost:3000`) but the upstream server needs the original `Host` header (e.g. `Host: store.example.com`) for virtual hosting, cookie domains, or redirect generation, there is no way to preserve it. The handler can set it, but `normalize_request` deletes it unconditionally.

## Solution

A zero-cost opt-in using `http::Extensions`:

```rust
// new public type in lib.rs
#[derive(Debug, Clone, Copy)]
pub struct PreserveHost;
```

```rust
// in normalize_request
if req.extensions().get::<crate::PreserveHost>().is_none() {
    req.headers_mut().remove(hyper::header::HOST);
}
```

Usage in a handler:

```rust
fn handle_request(&mut self, _ctx: &HttpContext, req: Request<Body>) -> RequestOrResponse {
    let (mut parts, body) = req.into_parts();
    parts.uri = rewritten_uri;
    parts.extensions.insert(hudsucker::PreserveHost);
    Request::from_parts(parts, body).into()
}
```

## Design choices

- **Extensions over builder flags**: No changes to `HttpHandler` trait, `ProxyBuilder`, or any public API. Extensions are already the idiomatic hyper mechanism for passing per-request metadata through middleware.
- **Opt-in, not opt-out**: Default behavior is unchanged. Existing users are unaffected. The `Host` header is only preserved when the handler explicitly requests it.
- **Zero cost when unused**: A single `Option::is_none()` check on a `TypeMap` lookup. No allocations, no branching in the common path beyond the type check.

## Tests

- Existing `removes_host_header` test passes unchanged
- New `preserves_host_header_with_extension` test verifies the opt-in path
- All 20 existing tests + 6 doctests pass

## Compatibility

- No breaking changes
- No new dependencies
- No feature flag required
- Backward compatible with all existing `HttpHandler` implementations
