### PR TITLE
fix(proxy): default to port 443 in CONNECT pass-through when authority lacks port

### DIFF
--- a/src/proxy/internal.rs
+++ b/src/proxy/internal.rs
@@ -245,12 +245,22 @@ where
                                 }
                             }
 
-                            let mut server = match TcpStream::connect(authority.as_ref()).await {
+                            // Some HTTP clients (notably bun/undici) emit CONNECT request-targets
+                            // where the port survives in `req.uri()` Display but not in
+                            // `req.uri().authority().as_str()`, leaving us with just the host.
+                            // Default to 443 when the port is absent so the raw tunnel can still
+                            // be established — virtually all CONNECT use is for HTTPS anyway.
+                            let connect_target = if authority.port_u16().is_some() {
+                                authority.as_str().to_owned()
+                            } else {
+                                format!("{}:443", authority.host())
+                            };
+                            let mut server = match TcpStream::connect(&connect_target).await {
                                 Ok(server) => server,
                                 Err(e) => {
                                     error!(
                                         error = &e as &dyn StdError,
-                                        "Failed to connect to {}", authority
+                                        "Failed to connect to {}", connect_target
                                     );
                                     return;
                                 }


### PR DESCRIPTION
## Problem

When `HttpHandler::should_intercept` returns `false` for a CONNECT request, the pass-through code calls:

```rust
let mut server = match TcpStream::connect(authority.as_ref()).await { ... }
```

Some HTTP clients (notably bun/undici) emit CONNECT request-targets where the port number survives in `req.uri()`'s Display output but is absent from `req.uri().authority().as_str()`. In that case `authority.as_ref()` is just the host string (e.g. `"example.com"`), which is not a valid socket address, and `TcpStream::connect` fails with:

```
Failed to connect to example.com: invalid socket address
```

The MITM path is unaffected because by the time it needs to open an upstream connection it already has a full request URI with default port info. Only the raw-tunnel path breaks.

## Reproduction

1. Build a proxy with a handler that returns `false` from `should_intercept` for non-target hosts.
2. Make a request through it from any bun-based client (or any client that emits CONNECT in this form).
3. Observe `Failed to connect to <host>: invalid socket address`.

## Fix

Default to port 443 when `authority.port_u16()` is `None`. Virtually all CONNECT usage is for HTTPS, and the alternative is a hard failure either way. If a non-HTTPS use case ever surfaces, a future change can plumb the original port through differently — but the current behavior is broken regardless.

## Test plan

- [x] Verified compiles cleanly with `cargo check`
- [x] Verified end-to-end against real proxy traffic from a bun-based HTTPS client — tunnels to `my.1password.com`, `pypi.org`, etc. all succeed (HTTP 200) where they previously errored.

## Notes

Happy to add unit tests if you'd like — let me know what shape you'd prefer (mock `Authority` without port, assert the constructed connect target is `host:443`).