### PR TITLE
fix(rcgen-ca): emit AKI extension on minted leaf certs

### DIFF
--- a/src/certificate_authority/rcgen_authority.rs
+++ b/src/certificate_authority/rcgen_authority.rs
@@ -84,6 +84,10 @@ impl RcgenAuthority {
             Ia5String::try_from(authority.host()).expect("Failed to create Ia5String"),
         ));
 
+        // RFC 5280 §4.2.1.1: non-self-issued certs MUST carry AKI; strict
+        // OpenSSL builds reject the chain otherwise.
+        params.use_authority_key_identifier_extension = true;
+
         params
             .signed_by(self.issuer.key(), &self.issuer)
             .expect("Failed to sign certificate")
@@ -163,5 +167,21 @@ mod tests {
 
         assert_ne!(cert1.raw_serial(), cert3.raw_serial());
         assert_ne!(cert2.raw_serial(), cert4.raw_serial());
+    }
+
+    #[test]
+    fn leaf_carries_authority_key_identifier() {
+        use x509_parser::extensions::ParsedExtension;
+
+        let ca = build_ca(0);
+        let der = ca.gen_cert(&Authority::from_static("example.com"));
+        let (_, cert) = x509_parser::parse_x509_certificate(&der).unwrap();
+        assert!(
+            cert.iter_extensions().any(|ext| matches!(
+                ext.parsed_extension(),
+                ParsedExtension::AuthorityKeyIdentifier(_)
+            )),
+            "leaf cert must carry an Authority Key Identifier extension",
+        );
     }
 }


### PR DESCRIPTION
python 3.13's bundled OpenSSL enforces [RFC-5280 §4.2.1.1](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.1), requiring the authority key identifier (AKI) extension to be included in all non self-issued certs. `RcgenAuthority::gen_cert` does not supply the AKI in the cert extensions because `rcgen` default `CertificateParams` field `use_authority_key_identifier_extension` defaults to false [here](https://docs.rs/rcgen/0.14.8/rcgen/struct.CertificateParams.html#structfield.use_authority_key_identifier_extension). this causes the following error:

```
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)
```

this PR sets the CertificateParams `use_authority_key_identifier_extension` flag to `true` so that the AKI is included in the certificate extensions. 

also adds a regression test to assert the AKI extension is present